### PR TITLE
Adds logs for melting with acid

### DIFF
--- a/code/modules/mob/living/carbon/alien/humanoid/alien_powers.dm
+++ b/code/modules/mob/living/carbon/alien/humanoid/alien_powers.dm
@@ -114,6 +114,11 @@ Doesn't work on other aliens/AI.*/
 			adjustToxLoss(-100)
 			new /obj/effect/alien/weak_acid(get_turf(O), O)
 			visible_message("\green <B>[src] vomits globs of vile stuff all over [O]. It begins to sizzle and melt under the bubbling mess of acid!</B>")
+			target = O
+			target.add_fingerprint(usr)
+			usr.attack_log +=  text("\[[time_stamp()]\]<font color='green'>[usr.name] spat acid at [target] (X=[target.x];Y=[target.y];Z=[target.z])</font>")
+			if(!istype(target,obj/item)) //We don't want to log ALL melts, only the ones that matter (structures, mostly). We don't care much if a jumpsuit was melted.
+				msg_admin_attack("[usr.name] ([usr.ckey]) spat acid at [target] (<A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[target.x];Y=[target.y];Z=[target.z]'>JMP</a>)")// RIGHT HERE
 		else
 			src << "\green Target is too far away."
 	return
@@ -160,6 +165,11 @@ Doesn't work on other aliens/AI.*/
 			adjustToxLoss(-200)
 			new /obj/effect/alien/acid(get_turf(O), O)
 			visible_message("\green <B>[src] vomits globs of vile stuff all over [O]. It begins to sizzle and melt under the bubbling mess of acid!</B>")
+			target = O
+			target.add_fingerprint(usr)
+			usr.attack_log +=  text("\[[time_stamp()]\]<font color='green'>[usr.name] spat acid at [target] (X=[target.x];Y=[target.y];Z=[target.z])</font>")
+			if(!istype(target,obj/item)) //We don't want to log ALL melts, only the ones that matter (structures, mostly). We don't care much if a jumpsuit was melted.
+				msg_admin_attack("[usr.name] ([usr.ckey]) spat acid at [target] (<A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[target.x];Y=[target.y];Z=[target.z]'>JMP</a>)")// RIGHT HERE
 		else
 			src << "\green Target is too far away."
 	return
@@ -199,6 +209,11 @@ Doesn't work on other aliens/AI.*/
 			adjustToxLoss(-300)
 			new /obj/effect/alien/superacid(get_turf(O), O)
 			visible_message("\green <B>[src] vomits globs of vile stuff all over [O]. It begins to sizzle and melt under the bubbling mess of acid!</B>")
+			target = O
+			target.add_fingerprint(usr)
+			usr.attack_log +=  text("\[[time_stamp()]\]<font color='green'>[usr.name] spat acid at [target] (X=[target.x];Y=[target.y];Z=[target.z])</font>")
+			if(!istype(target,obj/item)) //We don't want to log ALL melts, only the ones that matter (structures, mostly). We don't care much if a jumpsuit was melted.
+				msg_admin_attack("[usr.name] ([usr.ckey]) spat acid at [target] (<A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[target.x];Y=[target.y];Z=[target.z]'>JMP</a>)")// RIGHT HERE
 		else
 			src << "\green Target is too far away."
 	return


### PR DESCRIPTION
Using any of the three corrosive acids will leave an entry on the user's attack log and a fingerprint on the targeted object.
Furthermore, if the target is not an item (which means it is a structure, like a surgery table or a part of the PA), the action will be stored on the server logs.

Feature requested here:
http://www.colonial-marines.com/viewtopic.php?f=67&t=2392
